### PR TITLE
Fix fqdn entry not being created

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,7 +121,7 @@ class hosts (
   }
 
   if $use_fqdn_real == true {
-    @@host { $::fqdn:
+    host { $::fqdn:
       ensure       => $fqdn_ensure,
       host_aliases => $my_fqdn_host_aliases,
       ip           => $fqdn_ip,


### PR DESCRIPTION
Removed @@ from init.pp causing fqdn not being set on /etc/hosts file
